### PR TITLE
Fix some SQL related issues with upgrade patches

### DIFF
--- a/features/cerberusweb.core/patches/10.x/10.0.0.php
+++ b/features/cerberusweb.core/patches/10.x/10.0.0.php
@@ -38,7 +38,7 @@ if(!isset($tables['message_html_cache'])) {
 	
 	if('utf8mb4_unicode_ci' != $columns['html_content']['collation']) {
 		$db->ExecuteMaster("DELETE FROM message_html_cache");
-		$db->ExecuteMaster("ALTER TABLE message_html_cache MODIFY COLUMN html_content MEDIUMTEXT CHARACTER SET utf8mb4_unicode_ci");
+		$db->ExecuteMaster("ALTER TABLE message_html_cache MODIFY COLUMN html_content MEDIUMTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
 	}
 }
 

--- a/features/cerberusweb.core/patches/10.x/10.2.0.php
+++ b/features/cerberusweb.core/patches/10.x/10.2.0.php
@@ -36,6 +36,8 @@ if(!isset($tables['queue_message'])) {
 			`status_at` int unsigned NOT NULL DEFAULT 0,
 			`consumer_id` binary(16),
 			`message` TEXT,
+			-- This has been retroactively added to allow the elapsed_status_open migration to run when upgrading from pre-10.3.0.
+			`available_at` int unsigned NOT NULL DEFAULT 0,
 			PRIMARY KEY (uuid),
 			INDEX queue_claimed (queue_id, status_id, consumer_id)
 		) ENGINE=%s

--- a/features/cerberusweb.core/patches/9.x/9.6.0.php
+++ b/features/cerberusweb.core/patches/9.x/9.6.0.php
@@ -35,7 +35,7 @@ if(!array_key_exists('field_value', $columns))
 	return FALSE;
 
 if('utf8mb4_unicode_ci' != $columns['field_value']['collation']) {
-	$db->ExecuteMaster("ALTER TABLE custom_field_stringvalue MODIFY COLUMN field_value varchar(255) CHARACTER SET utf8mb4_unicode_ci COLLATE utf8mb4_unicode_ci");
+	$db->ExecuteMaster("ALTER TABLE custom_field_stringvalue MODIFY COLUMN field_value varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
 	$db->ExecuteMaster("REPAIR TABLE custom_field_stringvalue");
 	$db->ExecuteMaster("OPTIMIZE TABLE custom_field_stringvalue");
 }
@@ -52,7 +52,7 @@ if(!array_key_exists('field_value', $columns))
 	return FALSE;
 
 if('utf8mb4_unicode_ci' != $columns['field_value']['collation']) {
-	$db->ExecuteMaster("ALTER TABLE custom_field_clobvalue MODIFY COLUMN field_value MEDIUMTEXT CHARACTER SET utf8mb4_unicode_ci COLLATE utf8mb4_unicode_ci");
+	$db->ExecuteMaster("ALTER TABLE custom_field_clobvalue MODIFY COLUMN field_value MEDIUMTEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci");
 	$db->ExecuteMaster("REPAIR TABLE custom_field_clobvalue");
 	$db->ExecuteMaster("OPTIMIZE TABLE custom_field_clobvalue");
 }

--- a/libs/devblocks/patches/2.3.4.php
+++ b/libs/devblocks/patches/2.3.4.php
@@ -16,7 +16,7 @@ list($columns,) = $db->metaTable('devblocks_session');
 $changes = array();
 
 if(isset($columns['user_ip']) && 'varchar(64)' != $columns['user_ip']['type'])
-	$changes[] = "modify column user_ip varchar(64 not null default ''";
+	$changes[] = "modify column user_ip varchar(64) not null default ''";
 
 if(!empty($changes)) {
 	$sql = sprintf("ALTER TABLE devblocks_session %s", implode(', ', $changes));


### PR DESCRIPTION
I have been attempting to upgrade an older instance of Cerb (v8.0.0) up the latest one and ran into a couple of issues along the way.

The changes to devblocks v2.3.4 patch file was required to even get the upgrade to proceed, as the query failing there halts the upgrade process.

The changes related to the column and table collations didn't cause a crash, but the tables and columns renamed as their previous collation.

I had to backport the available_at column onto the cerberusweb.core 10.2.0 patch file as in the same patch it uses `enqueue` function to insert some jobs which require the `available_at` column to exist to insert, leading to the jobs to not actually be queued up.


I've noticed two additional warnings I noticed:

 - In the cerberusweb.core 8.3.0's patch file when it is processing the change to the `list_view` column it uses the `getChooserView` which attempts to get the currently logged in user, which does not exist in the upgrade context. My data appears to import across just fine, but it does produce a PHP notice.
 - In the cerberusweb.core 10.2.0's patch file when it is migrating the logo file it produces a few warnings about the table 'storage_resources' not existing yet, which I can see it dynamically creates. This migration occurs successfully oterwise.